### PR TITLE
1.增加 -o -p 参数 2.fix watchExt 无效

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,28 @@ go get github.com/silenceper/gowatch
 
 ![gowatch](./screenshot/gowatch.png)
 
-当文件变动会重新编译并执行。
 
-### 相关配置
+### 命令行参数
 
-大部分情况下，不需要更改配置，直接执行`gowatch`命令就能满足的大部分的需要，但是也提供了一些配置用于自定义，在执行目录下创建`gowatch.yml`文件，支持的配置如下：
+- -o : 非必须，指定build的目标文件路径
+- -p : 非必须，指定需要build的package（也可以是单个文件）
+
+例子:
+
+`gowatch -o ./bin/demo -p ./cmd/demo`
+
+### 配置文件
+`gowatch.yml`
+
+大部分情况下，不需要更改配置，直接执行`gowatch`命令就能满足的大部分的需要，但是也提供了一些配置用于自定义，在执行目录下创建`gowatch.yml`文件:
 
 ```
 # gowatch.yml 配置示例
 
 # 当前目录执行下生成的可执行文件的名字，默认是当前目录名
 appname: "test"   
-# 是否对当前目录下相关依赖执行 ‘go install’命令，将会执行安装依赖
-go_install: true
+# 指定编译后的目标文件目录 
+output: /bin/demo
 # 需要监听的文件名后缀，默认只有'.go'文件
 watch_exts:
     - .yml

--- a/config.go
+++ b/config.go
@@ -15,8 +15,6 @@ type config struct {
 	AppName string `yaml:"appname"`
 	//指定ouput执行的程序路径
 	Output string `yaml:"output"`
-	//是否执行'go install'命令，执行安装依赖
-	GoInstall bool `yaml:"go_install"`
 	//需要追加监听的文件后缀名字，默认是'.go'，
 	WatchExts []string `yaml:"watch_exts"`
 	//执行时的额外参数

--- a/config.go
+++ b/config.go
@@ -13,6 +13,8 @@ var configFile = "./gowatch.yml"
 type config struct {
 	//执行的app名字，默认当前目录文字
 	AppName string `yaml:"appname"`
+	//指定ouput执行的程序路径
+	Output string `yaml:"output"`
 	//是否执行'go install'命令，执行安装依赖
 	GoInstall bool `yaml:"go_install"`
 	//需要追加监听的文件后缀名字，默认是'.go'，

--- a/gowatch.go
+++ b/gowatch.go
@@ -228,15 +228,11 @@ func readAppDirectories(directory string, paths *[]string) {
 			readAppDirectories(directory+"/"+fileInfo.Name(), paths)
 			continue
 		}
-
 		if useDirectory == true {
 			continue
 		}
-
-		if path.Ext(fileInfo.Name()) == ".go" {
-			*paths = append(*paths, directory)
-			useDirectory = true
-		}
+		*paths = append(*paths, directory)
+		useDirectory = true
 	}
 	return
 }


### PR DESCRIPTION
增加-o ,-p 参数：

- -o  指定build 生成的二进制文件路径
- -p 指定需要编译的文件或文件夹路径

使用例子：
`gowatch -o=./bin/demo -p=cmd/demo`