### PR TITLE
增加app运行参数支持

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var (
 	exit     chan bool
 	output   string
 	buildPkg string
+	cmdArgs  string
 
 	started chan bool
 )
@@ -21,6 +22,7 @@ var (
 func init() {
 	flag.StringVar(&output, "o", "", "go build output")
 	flag.StringVar(&buildPkg, "p", "", "go build packages")
+	flag.StringVar(&cmdArgs, "args", "", "app run args,separated by commas. like: -args='-host=:8080,-name=demo'")
 }
 
 var ignoredFilesRegExps = []string{
@@ -55,6 +57,10 @@ func main() {
 			outputExt = ".exe"
 		}
 		cfg.Output = "./" + cfg.AppName + outputExt
+	}
+
+	if cmdArgs != "" {
+		cfg.CmdArgs = strings.Split(cmdArgs, ",")
 	}
 
 	//监听的文件后缀

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,7 +15,7 @@
 			"revisionTime": "2016-12-24T17:04:52Z"
 		},
 		{
-			"checksumSHA1": "C01MqZp5G0X2eKm7MdinO2zjJJA=",
+			"checksumSHA1": "5/beHjGfngQV/0QOP3QpQV/t9ag=",
 			"path": "github.com/silenceper/gowatch",
 			"revision": "e30fb0ab6514fbc4fa8f4c54eceb1f36271a72f1",
 			"revisionTime": "2016-12-24T17:06:31Z"


### PR DESCRIPTION
支持直接在gowatch后增加-args参数，以逗号分隔，注：将会覆盖gowatch.yml文件中的配置

```
gowatch -args="-host=:8080,-name=demo,-register=false"

```