### PR TITLE
fix: gowatch restarts infinitely when a templ command is used

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -54,7 +53,7 @@ func parseConfig(confPath string) *config {
 	if !fileExist(filename) {
 		return c
 	}
-	yamlFile, err := ioutil.ReadFile(filename)
+	yamlFile, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,16 @@
 module github.com/silenceper/gowatch
 
-go 1.14
+go 1.24
 
 require (
-	github.com/fsnotify/fsnotify v1.5.1
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/mitchellh/go-ps v1.0.0
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/silenceper/log v0.0.0-20171204144354-e5ac7fa8a76a
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
+)
+
+require (
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -9,8 +9,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/silenceper/log v0.0.0-20171204144354-e5ac7fa8a76a h1:COf2KvPmardI1M8p2fhHsXlFS2EXSQygbGgcDYBI9Wc=
 github.com/silenceper/log v0.0.0-20171204144354-e5ac7fa8a76a/go.mod h1:nyN/YUSK3CgJjtNzm6dVTkcou+RYXNMP+XLSlzQu0m0=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=

--- a/gowatch.go
+++ b/gowatch.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	path "path/filepath"
@@ -135,10 +134,13 @@ func Autobuild(files []string) {
 		prevCmdExec.Stderr = os.Stderr
 		err := prevCmdExec.Run()
 		if err != nil {
-			panic(err)
+			log.Error(fmt.Sprintf("pref_build_cmds failed: %s", err.Error()))
+			time.Sleep(3 * time.Second)
+			Restart(cfg.Output, false)
 		}
 	}
 
+	time.Sleep(time.Second)
 	cmdName := "go"
 
 	var err error
@@ -347,7 +349,7 @@ func checkIfWatchExt(name string) bool {
 }
 
 func readAppDirectories(directory string, paths *[]string) {
-	fileInfos, err := ioutil.ReadDir(directory)
+	fileInfos, err := os.ReadDir(directory)
 	if err != nil {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	path "path/filepath"
 	"runtime"
@@ -111,7 +110,7 @@ func main() {
 	// init gowatch.yml
 	if len(os.Args) > 1 && os.Args[1] == "init" {
 		if _, err := os.Stat("gowatch.yml"); errors.Is(err, fs.ErrNotExist) {
-			_ = ioutil.WriteFile("gowatch.yml", []byte(defaultYml), 0755)
+			_ = os.WriteFile("gowatch.yml", []byte(defaultYml), 0755)
 			fmt.Println("gowatch.yml file created to the current directory with the default settings")
 		} else {
 			fmt.Println("gowatch.yml has been exists")


### PR DESCRIPTION
Hi thanks for building this software!

I'm using `gowatch` with [templ](https://github.com/a-h/templ) templates. Currently, when I add the pre-build command `templ generate`, `gowatch` finishes the build, runs the app but restarts infinitely.

```yml
prev_build_cmds:
  - templ generate
```

Adding a small timeout fixed the problem

Another issue was that `gowatch` crashes when the `pre-build` command fails, e.g due to invalid template config.
Fixed this by adding restart instead of panic.